### PR TITLE
feat: refactor circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
     working_directory: ~/repo
 
     steps:
+    - run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
       - checkout
       - run: 
           name: Build and install dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
       - checkout
       # Download and cache dependencies
       - restore_cache:
@@ -15,18 +17,40 @@ jobs:
       - run: 
           name: Build and install dependencies
           command: npm install
+      - run:
+          command: fossa init
+          working_directory: ~/repo
+      - run:
+          command: fossa analyze
+          working_directory: ~/repo
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-      # run tests!
+  test:
+    docker:
+      - image: circleci/node:lts-jessie
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
       - run: 
           name: Run tests with JUnit as reporter
           command: ./node_modules/.bin/jest --collect-coverage --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: test-results
+      - run:
+          name: Run Fossa Licences Test
+          command: fossa test
+          working_directory: <repo_dir>
       - store_artifacts:
           path: coverage
       - store_test_results:
           path: test-results
-
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
-    - run: |
+      - run: |
           curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
       - checkout
       - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,6 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
       - checkout
       # Download and cache dependencies
       - restore_cache:
@@ -17,12 +15,6 @@ jobs:
       - run: 
           name: Build and install dependencies
           command: npm install
-      - run:
-          command: fossa init
-          working_directory: ~/repo
-      - run:
-          command: fossa analyze
-          working_directory: ~/repo
       - save_cache:
           paths:
             - node_modules
@@ -34,8 +26,6 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
       - checkout
       - run: 
           name: Build and install dependencies
@@ -45,10 +35,6 @@ jobs:
           command: ./node_modules/.bin/jest --collect-coverage --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: test-results
-      - run:
-          name: Run Fossa Licences Test
-          command: fossa test
-          working_directory: <repo_dir>
       - store_artifacts:
           path: coverage
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
 
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
       - run: 
           name: Build and install dependencies
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - checkout
       - run: 
+          name: Build and install dependencies
+          command: npm install
+      - run: 
           name: Run tests with JUnit as reporter
           command: ./node_modules/.bin/jest --collect-coverage --ci --runInBand --reporters=default --reporters=jest-junit
           environment:


### PR DESCRIPTION
# CI Refactor
## Why ?

CircleCI is accepting workflow build separing test and build part. This allows, where possible, to paralleling execute the steps.

## What ?

With the proposed configuration, each PR/Push is causing 2 parallel builds on CircleCI: one for the building part and one for the testing part.
Both 2 steps are mandatory to allow the PR merge.

![image](https://user-images.githubusercontent.com/139323/59967884-3cf2ec00-9531-11e9-9d26-bd9983c3f9a4.png)

![image](https://user-images.githubusercontent.com/139323/59967894-5dbb4180-9531-11e9-80ab-9d080a04ef39.png)
