### PR TITLE
feat: added circleci build badge on the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Github auto-labeler action
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FDecathlon%2Fpull-request-labeler-action.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FDecathlon%2Fpull-request-labeler-action?ref=badge_shield)
+[![CircleCI](https://circleci.com/gh/Decathlon/pull-request-labeler-action/tree/master.svg?style=svg)](https://circleci.com/gh/Decathlon/pull-request-labeler-action/tree/master)
 
 GitHub actions to auto label a pull request based on committed files.
 


### PR DESCRIPTION
# Project Information Badges

## Why and What?
To give to the project users fresh information about what is happening behind, and allow them to chose a version knowing if it is good or not, a new CircleCI badge is added with the information about the master branch build.

![image](https://user-images.githubusercontent.com/139323/60349457-ecacdb80-99c1-11e9-8aad-e6395170e16f.png)
