### PR TITLE
fix: use v1.0.2 to solve github action v2 regressions

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         args: action closed
     - name: Create Release Notes
-      uses: docker://decathlon/release-notes-generator-action:1.0.1
+      uses: docker://decathlon/release-notes-generator-action:1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         OUTPUT_FOLDER: temp_release_notes


### PR DESCRIPTION
Hello,
Since GitHub action beta2, GitHub is specifying a --workdir folder.
The release-notes action v1.0.1 was downloading the springboot jar on the fly. But now as the workdir is specified, the shell script is unable to find it (not on the expected folder).
This was already fixed on the master, but no new release was avalailble, so i built the 1.0.2.
I need to upgrade here...
Regards,
Alexandre.