### PR TITLE
fix: wiki page creator action v1.0.0 is outdated

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -16,7 +16,7 @@ jobs:
         OUTPUT_FOLDER: temp_release_notes
         USE_MILESTONE_TITLE: "true"
     - name: Upload Release Notes to Wiki
-      uses: docker://decathlon/wiki-page-creator-action:1.0.0
+      uses: docker://decathlon/wiki-page-creator-action:latest
       env:
         ACTION_MAIL: oss@decathlon.com
         ACTION_NAME: decathlonbot


### PR DESCRIPTION
The current version uses an environment variable (WIKI_REPO_URL) that is not required by the current version.
Plus current build is failing due to that.