### PR TITLE
fix(dependencies): force actions-toolkit and octokit/rest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "build:main": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "actions-toolkit": "^2.1.0",
+    "actions-toolkit": "2.1.0",
     "jest-junit": "^6.4.0"
   },
   "devDependencies": {
-    "@octokit/rest": "^16.28.1",
+    "@octokit/rest": "16.28.1",
     "@types/jest": "^24.0.15",
     "awesome-typescript-loader": "^5.2.1",
     "jest": "^24.8.0",


### PR DESCRIPTION
Octokit/rest and actions-toolkit versions were upgraded and caused breaking changes that need to be taken into account (see issue #32)